### PR TITLE
fix draw.lines() with all lines clipped

### DIFF
--- a/pygame/draw.py
+++ b/pygame/draw.py
@@ -272,7 +272,10 @@ def lines(surface, color, closed, points, width=1):
             _clip_and_draw_line_width(
                 surface, c_color, width, points[-1], points[0])
 
-    return _make_drawn_rect(drawn_points, surface)
+    if drawn_points:
+        # points would be empty if nothing was drawn
+        return _make_drawn_rect(drawn_points, surface)
+    return None
 
 
 def _draw_fillpoly(surface, points, c_color):


### PR DESCRIPTION
If the set of lines given to draw.lines() are all outside the surface,
it will pass _make_drawn_rect() an empty array and trigger an
exception.

This patch makes it return None instead in this case. See
_clip_and_draw_line_width() for similar code.