### PR TITLE
Feature/smoothscale

### DIFF
--- a/cffi_builders/lib/smoothscale.c
+++ b/cffi_builders/lib/smoothscale.c
@@ -1,0 +1,328 @@
+
+/*
+ * smooth scale functions.
+ */
+
+
+/* this function implements an area-averaging shrinking filter in the X-dimension */
+static void filter_shrink_X(Uint8 *srcpix, Uint8 *dstpix, int height, int srcpitch, int dstpitch, int srcwidth, int dstwidth)
+{
+    int srcdiff = srcpitch - (srcwidth * 4);
+    int dstdiff = dstpitch - (dstwidth * 4);
+    int x, y;
+
+    int xspace = 0x10000 * srcwidth / dstwidth; /* must be > 1 */
+    int xrecip = (int) (0x100000000LL / xspace);
+    for (y = 0; y < height; y++)
+    {
+        Uint16 accumulate[4] = {0,0,0,0};
+        int xcounter = xspace;
+        for (x = 0; x < srcwidth; x++)
+        {
+            if (xcounter > 0x10000)
+            {
+                accumulate[0] += (Uint16) *srcpix++;
+                accumulate[1] += (Uint16) *srcpix++;
+                accumulate[2] += (Uint16) *srcpix++;
+                accumulate[3] += (Uint16) *srcpix++;
+                xcounter -= 0x10000;
+            }
+            else
+            {
+                int xfrac = 0x10000 - xcounter;
+                /* write out a destination pixel */
+                *dstpix++ = (Uint8) (((accumulate[0] + ((srcpix[0] * xcounter) >> 16)) * xrecip) >> 16);
+                *dstpix++ = (Uint8) (((accumulate[1] + ((srcpix[1] * xcounter) >> 16)) * xrecip) >> 16);
+                *dstpix++ = (Uint8) (((accumulate[2] + ((srcpix[2] * xcounter) >> 16)) * xrecip) >> 16);
+                *dstpix++ = (Uint8) (((accumulate[3] + ((srcpix[3] * xcounter) >> 16)) * xrecip) >> 16);
+                /* reload the accumulator with the remainder of this pixel */
+                accumulate[0] = (Uint16) ((*srcpix++ * xfrac) >> 16);
+                accumulate[1] = (Uint16) ((*srcpix++ * xfrac) >> 16);
+                accumulate[2] = (Uint16) ((*srcpix++ * xfrac) >> 16);
+                accumulate[3] = (Uint16) ((*srcpix++ * xfrac) >> 16);
+                xcounter = xspace - xfrac;
+            }
+        }
+        srcpix += srcdiff;
+        dstpix += dstdiff;
+    }
+}
+
+/* this function implements an area-averaging shrinking filter in the Y-dimension */
+static void filter_shrink_Y(Uint8 *srcpix, Uint8 *dstpix, int width, int srcpitch, int dstpitch, int srcheight, int dstheight)
+{
+    Uint16 *templine;
+    int srcdiff = srcpitch - (width * 4);
+    int dstdiff = dstpitch - (width * 4);
+    int x, y;
+    int yspace = 0x10000 * srcheight / dstheight; /* must be > 1 */
+    int yrecip = (int) (0x100000000LL / yspace);
+    int ycounter = yspace;
+
+    /* allocate and clear a memory area for storing the accumulator line */
+    templine = (Uint16 *) malloc(dstpitch * 2);
+    if (templine == NULL) return;
+    memset(templine, 0, dstpitch * 2);
+
+    for (y = 0; y < srcheight; y++)
+    {
+        Uint16 *accumulate = templine;
+        if (ycounter > 0x10000)
+        {
+            for (x = 0; x < width; x++)
+            {
+                *accumulate++ += (Uint16) *srcpix++;
+                *accumulate++ += (Uint16) *srcpix++;
+                *accumulate++ += (Uint16) *srcpix++;
+                *accumulate++ += (Uint16) *srcpix++;
+            }
+            ycounter -= 0x10000;
+        }
+        else
+        {
+            int yfrac = 0x10000 - ycounter;
+            /* write out a destination line */
+            for (x = 0; x < width; x++)
+            {
+                *dstpix++ = (Uint8) (((*accumulate++ + ((*srcpix++ * ycounter) >> 16)) * yrecip) >> 16);
+                *dstpix++ = (Uint8) (((*accumulate++ + ((*srcpix++ * ycounter) >> 16)) * yrecip) >> 16);
+                *dstpix++ = (Uint8) (((*accumulate++ + ((*srcpix++ * ycounter) >> 16)) * yrecip) >> 16);
+                *dstpix++ = (Uint8) (((*accumulate++ + ((*srcpix++ * ycounter) >> 16)) * yrecip) >> 16);
+            }
+            dstpix += dstdiff;
+            /* reload the accumulator with the remainder of this line */
+            accumulate = templine;
+            srcpix -= 4 * width;
+            for (x = 0; x < width; x++)
+            {
+                *accumulate++ = (Uint16) ((*srcpix++ * yfrac) >> 16);
+                *accumulate++ = (Uint16) ((*srcpix++ * yfrac) >> 16);
+                *accumulate++ = (Uint16) ((*srcpix++ * yfrac) >> 16);
+                *accumulate++ = (Uint16) ((*srcpix++ * yfrac) >> 16);
+            }
+            ycounter = yspace - yfrac;
+        }
+        srcpix += srcdiff;
+    } /* for (int y = 0; y < srcheight; y++) */
+
+    /* free the temporary memory */
+    free(templine);
+}
+
+/* this function implements a bilinear filter in the X-dimension */
+static void filter_expand_X(Uint8 *srcpix, Uint8 *dstpix, int height, int srcpitch, int dstpitch, int srcwidth, int dstwidth)
+{
+    int dstdiff = dstpitch - (dstwidth * 4);
+    int *xidx0, *xmult0, *xmult1;
+    int x, y;
+    int factorwidth = 4;
+
+    /* Allocate memory for factors */
+    xidx0 = malloc(dstwidth * 4);
+    if (xidx0 == NULL) return;
+    xmult0 = (int *) malloc(dstwidth * factorwidth);
+    xmult1 = (int *) malloc(dstwidth * factorwidth);
+    if (xmult0 == NULL || xmult1 == NULL)
+    {
+        free(xidx0);
+        if (xmult0) free(xmult0);
+        if (xmult1) free(xmult1);
+    }
+
+    /* Create multiplier factors and starting indices and put them in arrays */
+    for (x = 0; x < dstwidth; x++)
+    {
+        xidx0[x] = x * (srcwidth - 1) / dstwidth;
+        xmult1[x] = 0x10000 * ((x * (srcwidth - 1)) % dstwidth) / dstwidth;
+        xmult0[x] = 0x10000 - xmult1[x];
+    }
+
+    /* Do the scaling in raster order so we don't trash the cache */
+    for (y = 0; y < height; y++)
+    {
+        Uint8 *srcrow0 = srcpix + y * srcpitch;
+        for (x = 0; x < dstwidth; x++)
+        {
+            Uint8 *src = srcrow0 + xidx0[x] * 4;
+            int xm0 = xmult0[x];
+            int xm1 = xmult1[x];
+            *dstpix++ = (Uint8) (((src[0] * xm0) + (src[4] * xm1)) >> 16);
+            *dstpix++ = (Uint8) (((src[1] * xm0) + (src[5] * xm1)) >> 16);
+            *dstpix++ = (Uint8) (((src[2] * xm0) + (src[6] * xm1)) >> 16);
+            *dstpix++ = (Uint8) (((src[3] * xm0) + (src[7] * xm1)) >> 16);
+        }
+        dstpix += dstdiff;
+    }
+
+    /* free memory */
+    free(xidx0);
+    free(xmult0);
+    free(xmult1);
+}
+
+/* this function implements a bilinear filter in the Y-dimension */
+static void filter_expand_Y(Uint8 *srcpix, Uint8 *dstpix, int width, int srcpitch, int dstpitch, int srcheight, int dstheight)
+{
+    int x, y;
+
+    for (y = 0; y < dstheight; y++)
+    {
+        int yidx0 = y * (srcheight - 1) / dstheight;
+        Uint8 *srcrow0 = srcpix + yidx0 * srcpitch;
+        Uint8 *srcrow1 = srcrow0 + srcpitch;
+        int ymult1 = 0x10000 * ((y * (srcheight - 1)) % dstheight) / dstheight;
+        int ymult0 = 0x10000 - ymult1;
+        for (x = 0; x < width; x++)
+        {
+            *dstpix++ = (Uint8) (((*srcrow0++ * ymult0) + (*srcrow1++ * ymult1)) >> 16);
+            *dstpix++ = (Uint8) (((*srcrow0++ * ymult0) + (*srcrow1++ * ymult1)) >> 16);
+            *dstpix++ = (Uint8) (((*srcrow0++ * ymult0) + (*srcrow1++ * ymult1)) >> 16);
+            *dstpix++ = (Uint8) (((*srcrow0++ * ymult0) + (*srcrow1++ * ymult1)) >> 16);
+        }
+    }
+}
+
+
+static void convert_24_32(Uint8 *srcpix, int srcpitch, Uint8 *dstpix, int dstpitch, int width, int height)
+{
+    int srcdiff = srcpitch - (width * 3);
+    int dstdiff = dstpitch - (width * 4);
+    int x, y;
+
+    for (y = 0; y < height; y++)
+    {
+        for (x = 0; x < width; x++)
+        {
+            *dstpix++ = *srcpix++;
+            *dstpix++ = *srcpix++;
+            *dstpix++ = *srcpix++;
+            *dstpix++ = 0xff;
+        }
+        srcpix += srcdiff;
+        dstpix += dstdiff;
+    }
+}
+
+static void convert_32_24(Uint8 *srcpix, int srcpitch, Uint8 *dstpix, int dstpitch, int width, int height)
+{
+    int srcdiff = srcpitch - (width * 4);
+    int dstdiff = dstpitch - (width * 3);
+    int x, y;
+
+    for (y = 0; y < height; y++)
+    {
+        for (x = 0; x < width; x++)
+        {
+            *dstpix++ = *srcpix++;
+            *dstpix++ = *srcpix++;
+            *dstpix++ = *srcpix++;
+            srcpix++;
+        }
+        srcpix += srcdiff;
+        dstpix += dstdiff;
+    }
+}
+
+static void
+scalesmooth(SDL_Surface *src, SDL_Surface *dst)
+{
+    Uint8* srcpix = (Uint8*)src->pixels;
+    Uint8* dstpix = (Uint8*)dst->pixels;
+    Uint8* dst32 = NULL;
+    int srcpitch = src->pitch;
+    int dstpitch = dst->pitch;
+
+    int srcwidth = src->w;
+    int srcheight = src->h;
+    int dstwidth = dst->w;
+    int dstheight = dst->h;
+
+    int bpp = src->format->BytesPerPixel;
+
+    Uint8 *temppix = NULL;
+    int tempwidth=0, temppitch=0, tempheight=0;
+
+    /* convert to 32-bit if necessary */
+    if (bpp == 3)
+    {
+        int newpitch = srcwidth * 4;
+        Uint8 *newsrc = (Uint8 *) malloc(newpitch * srcheight);
+        if (!newsrc)
+            return;
+        convert_24_32(srcpix, srcpitch, newsrc, newpitch, srcwidth, srcheight);
+        srcpix = newsrc;
+        srcpitch = newpitch;
+        /* create a destination buffer for the 32-bit result */
+        dstpitch = dstwidth << 2;
+        dst32 = (Uint8 *) malloc(dstpitch * dstheight);
+        if (dst32 == NULL)
+        {
+            free(srcpix);
+            return;
+        }
+        dstpix = dst32;
+    }
+
+    /* Create a temporary processing buffer if we will be scaling both X and Y */
+    if (srcwidth != dstwidth && srcheight != dstheight)
+    {
+        tempwidth = dstwidth;
+        temppitch = tempwidth << 2;
+        tempheight = srcheight;
+        temppix = (Uint8 *) malloc(temppitch * tempheight);
+        if (temppix == NULL)
+        {
+            if (bpp == 3)
+            {
+                free(srcpix);
+                free(dstpix);
+            }
+            return;
+        }
+    }
+
+    /* Start the filter by doing X-scaling */
+    if (dstwidth < srcwidth) /* shrink */
+    {
+        if (srcheight != dstheight)
+            filter_shrink_X(srcpix, temppix, srcheight, srcpitch, temppitch, srcwidth, dstwidth);
+        else
+            filter_shrink_X(srcpix, dstpix, srcheight, srcpitch, dstpitch, srcwidth, dstwidth);
+    }
+    else if (dstwidth > srcwidth) /* expand */
+    {
+        if (srcheight != dstheight)
+            filter_expand_X(srcpix, temppix, srcheight, srcpitch, temppitch, srcwidth, dstwidth);
+        else
+            filter_expand_X(srcpix, dstpix, srcheight, srcpitch, dstpitch, srcwidth, dstwidth);
+    }
+    /* Now do the Y scale */
+    if (dstheight < srcheight) /* shrink */
+    {
+        if (srcwidth != dstwidth)
+            filter_shrink_Y(temppix, dstpix, tempwidth, temppitch, dstpitch, srcheight, dstheight);
+        else
+            filter_shrink_Y(srcpix, dstpix, srcwidth, srcpitch, dstpitch, srcheight, dstheight);
+    }
+    else if (dstheight > srcheight)  /* expand */
+    {
+        if (srcwidth != dstwidth)
+            filter_expand_Y(temppix, dstpix, tempwidth, temppitch, dstpitch, srcheight, dstheight);
+        else
+            filter_expand_Y(srcpix, dstpix, srcwidth, srcpitch, dstpitch, srcheight, dstheight);
+    }
+
+    /* Convert back to 24-bit if necessary */
+    if (bpp == 3)
+    {
+        convert_32_24(dst32, dstpitch, (Uint8*)dst->pixels, dst->pitch, dstwidth, dstheight);
+        free(dst32);
+        dst32 = NULL;
+        free(srcpix);
+        srcpix = NULL;
+    }
+    /* free temporary buffer if necessary */
+    if (temppix != NULL)
+        free(temppix);
+
+}

--- a/cffi_builders/sdl_c_build.py
+++ b/cffi_builders/sdl_c_build.py
@@ -594,6 +594,7 @@ static void rotate90(SDL_Surface *src, SDL_Surface *dst, int angle);
 static void rotate(SDL_Surface *src, SDL_Surface *dst, Uint32 bgcolor,
     double sangle, double cangle);
 static void stretch (SDL_Surface *src, SDL_Surface *dst);
+static void scalesmooth(SDL_Surface *src, SDL_Surface *dst);
 """)
 
 sdl = ffi.set_source(
@@ -885,6 +886,8 @@ sdl = ffi.set_source(
     %(rotate)s
 
     %(stretch)s
+
+    %(smoothscale)s
     """ % {
         'surface_h': _get_c_lib('surface.h'),
         'alphablit': _get_c_lib('alphablit.c'),
@@ -892,6 +895,7 @@ sdl = ffi.set_source(
         'scale2x': _get_c_lib('scale2x.c'),
         'rotate': _get_c_lib('rotate.c'),
         'stretch': _get_c_lib('stretch.c'),
+        'smoothscale': _get_c_lib('smoothscale.c'),
     }
 )
 

--- a/conformance/conf_tests/__init__.py
+++ b/conformance/conf_tests/__init__.py
@@ -13,7 +13,8 @@ from .test_surface import test_scroll
 from .test_blending import (test_rgba_add, test_rgba_sub, test_rgba_min,
                             test_rgba_max, test_rgba_mult, test_rgb_mult,
                             test_blend_mult)
-
+from .test_smoothscale import (test_int_smoothscale, test_x_smoothscale,
+                               test_y_smoothscale, test_varied_smoothscale)
 
 conformance_tests = {
     'test_rgba_add': test_rgba_add,
@@ -35,7 +36,11 @@ conformance_tests = {
     'rotate': test_rotate,
     'rect': test_rect,
     'polygon': test_polygon,
-    'scroll': test_scroll
+    'scroll': test_scroll,
+    'smooth_int': test_int_smoothscale,
+    'smooth_x': test_x_smoothscale,
+    'smooth_y': test_y_smoothscale,
+    'smooth_varies': test_varied_smoothscale,
 }
 
 

--- a/conformance/conf_tests/test_smoothscale.py
+++ b/conformance/conf_tests/test_smoothscale.py
@@ -17,6 +17,8 @@ def test_int_smoothscale(surface):
     """Simple integer scaling tests"""
     obj = _make_object()
 
+    transform.set_smoothscale_backend('GENERIC')
+
     surface.blit(obj, (20, 20))
     obj1 = transform.smoothscale(obj, (20, 20))
     surface.blit(obj1, (60, 60))
@@ -31,6 +33,8 @@ def test_int_smoothscale(surface):
 def test_x_smoothscale(surface):
     """Scale x axis only"""
     obj = _make_object()
+
+    transform.set_smoothscale_backend('GENERIC')
 
     surface.blit(obj, (20, 20))
     obj1 = transform.smoothscale(obj, (25, 20))
@@ -49,6 +53,8 @@ def test_y_smoothscale(surface):
     """Scale y axis only"""
     obj = _make_object()
 
+    transform.set_smoothscale_backend('GENERIC')
+
     surface.blit(obj, (20, 20))
     obj1 = transform.smoothscale(obj, (20, 25))
     surface.blit(obj1, (80, 80))
@@ -65,6 +71,8 @@ def test_y_smoothscale(surface):
 def test_varied_smoothscale(surface):
     """Scale with more varies factors"""
     obj = _make_object()
+
+    transform.set_smoothscale_backend('GENERIC')
 
     surface.blit(obj, (20, 20))
     obj1 = transform.smoothscale(obj, (25, 55))

--- a/conformance/conf_tests/test_smoothscale.py
+++ b/conformance/conf_tests/test_smoothscale.py
@@ -1,0 +1,75 @@
+# Simple transform tests
+
+from pygame import transform, surface, draw
+
+
+def _make_object():
+    """Create a vaguely interesting object to transform."""
+    obj = surface.Surface((40, 80), depth=32)
+    draw.line(obj, (255, 0, 0, 255), (10, 10), (10, 40), 3)
+    draw.line(obj, (255, 255, 0, 255), (10, 10), (40, 10), 3)
+    draw.line(obj, (255, 128, 128, 255), (40, 10), (40, 40), 2)
+    draw.lines(obj, (255, 255, 255, 255), 1, [(20, 20), (20, 30), (30, 30)])
+    return obj
+
+
+def test_int_smoothscale(surface):
+    """Simple integer scaling tests"""
+    obj = _make_object()
+
+    surface.blit(obj, (20, 20))
+    obj1 = transform.smoothscale(obj, (20, 20))
+    surface.blit(obj1, (60, 60))
+    obj1 = transform.smoothscale(obj, (40, 40))
+    surface.blit(obj1, (80, 80))
+    obj1 = transform.smoothscale(obj, (60, 60))
+    surface.blit(obj1, (160, 160))
+    obj1 = transform.smoothscale(obj, (120, 120))
+    surface.blit(obj1, (320, 320))
+
+
+def test_x_smoothscale(surface):
+    """Scale x axis only"""
+    obj = _make_object()
+
+    surface.blit(obj, (20, 20))
+    obj1 = transform.smoothscale(obj, (25, 20))
+    surface.blit(obj1, (80, 80))
+    obj2 = transform.smoothscale(obj, (35, 20))
+    surface.blit(obj2, (160, 160))
+    obj3 = transform.smoothscale(obj, (55, 20))
+    surface.blit(obj3, (240, 160))
+    obj4 = transform.smoothscale(obj, (15, 20))
+    surface.blit(obj4, (240, 240))
+    obj5 = transform.smoothscale(obj, (100, 20))
+    surface.blit(obj5, (320, 320))
+
+
+def test_y_smoothscale(surface):
+    """Scale y axis only"""
+    obj = _make_object()
+
+    surface.blit(obj, (20, 20))
+    obj1 = transform.smoothscale(obj, (20, 25))
+    surface.blit(obj1, (80, 80))
+    obj2 = transform.smoothscale(obj, (20, 35))
+    surface.blit(obj2, (160, 160))
+    obj3 = transform.smoothscale(obj, (20, 55))
+    surface.blit(obj3, (240, 160))
+    obj4 = transform.smoothscale(obj, (20, 15))
+    surface.blit(obj4, (240, 240))
+    obj5 = transform.smoothscale(obj, (20, 100))
+    surface.blit(obj5, (320, 320))
+
+
+def test_varied_smoothscale(surface):
+    """Scale with more varies factors"""
+    obj = _make_object()
+
+    surface.blit(obj, (20, 20))
+    obj1 = transform.smoothscale(obj, (25, 55))
+    surface.blit(obj1, (80, 80))
+    obj1 = transform.smoothscale(obj, (14, 13))
+    surface.blit(obj1, (160, 160))
+    obj1 = transform.smoothscale(obj, (72, 68))
+    surface.blit(obj1, (320, 320))

--- a/pygame/transform.py
+++ b/pygame/transform.py
@@ -215,7 +215,10 @@ def smoothscale(surface, (width, height), dest_surface=None):
 
     if new_surf.w != width or new_surf.h != height:
         raise ValueError("Destination surface not the given width or height.")
-    # TODO: Check alignment
+
+    if (width * bpp + 3) // 4 > new_surf.pitch:
+        raise ValueError("SDL Error: destination surface pitch not"
+                         " 4-byte aligned.")
 
     if width and height:
         with locked(new_surf):

--- a/pygame/transform.py
+++ b/pygame/transform.py
@@ -198,21 +198,59 @@ def smoothscale(surface, (width, height), dest_surface=None):
     """ smoothscale(Surface, (width, height), DestSurface = None) -> Surface
     scale a surface to an arbitrary size smoothly
     """
-    raise NotImplementedError
+    if width < 0 or height < 0:
+        raise ValueError("Cannot scale to negative size")
+
+    c_surf = surface._c_surface
+
+    bpp = c_surf.format.BytesPerPixel
+    if bpp < 3 or bpp > 4:
+        raise ValueError("Only 24-bit or 32-bit surfaces can be"
+                         " smoothly scaled")
+
+    if dest_surface is None:
+        new_surf = new_surface_from_surface(c_surf, width, height)
+    else:
+        new_surf = dest_surface._c_surface
+
+    if new_surf.w != width or new_surf.h != height:
+        raise ValueError("Destination surface not the given width or height.")
+    # TODO: Check alignment
+
+    if width and height:
+        with locked(new_surf):
+            with locked(c_surf):
+                if c_surf.w == width and c_surf.h == height:
+                    pitch = c_surf.pitch
+                    # Trivial case
+                    srcpixels = ffi.cast('uint8_t*', c_surf.pixels)
+                    destpixels = ffi.cast('uint8_t*', new_surf.pixels)
+                    destpixels[0:height * pitch] = srcpixels[0:height * pitch]
+                else:
+                    sdl.scalesmooth(c_surf, new_surf)
+    if dest_surface:
+        return dest_surface
+    return Surface._from_sdl_surface(new_surf)
 
 
 def get_smoothscale_backend():
     """ get_smoothscale_backend() -> String
     return smoothscale filter version in use: 'GENERIC', 'MMX', or 'SSE'
     """
-    raise NotImplementedError
+    # For now, we just implement GENERIC
+    return 'GENERIC'
 
 
 def set_smoothscale_backend(type):
     """ set_smoothscale_backend(type) -> None
     set smoothscale filter version to one of: 'GENERIC', 'MMX', or 'SSE'
     """
-    raise NotImplementedError
+    # for now, we just implement GENERIC
+    if type == 'GENERIC':
+        return
+    elif type == 'MMX' or type == 'SSE':
+        raise ValueError('%s not supported on this machine' % type)
+    raise ValueError("Unknown backend type %s" % type)
 
 
 def chop(surface, rect):


### PR DESCRIPTION
This implements transform.smoothscale, using the C-only generic implementation.

This doesn't attempt to duplicate the optimised MMX and SSE implementations pygame provides as they give slightly different visual results and the complexity doesn't seem worth it for something so x86 specific.

This should be enough to close issue #7 