### PR TITLE
Tweak gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,4 @@ nosetests.xml
 .project
 .pydevproject
 
-# Ignore CFFI generated .c modules
-*.c
 /pygame/_macosx_c.m

--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,8 @@ var
 sdist
 develop-eggs
 .installed.cfg
-lib
-lib64
+/lib
+/lib64
 __pycache__
 examples
 


### PR DESCRIPTION
This makes .gitignore much less aggressive about ignoring *.c files, which makes extending cffi_builder/lib easier.