### PR TITLE
Fix print usage so conformance tests can run under python 3

### DIFF
--- a/conformance/conf_tests/helpers.py
+++ b/conformance/conf_tests/helpers.py
@@ -1,4 +1,5 @@
 # Helper functions for the conformance tests
+from __future__ import print_function
 
 from pygame import surface, image
 from pygame.locals import SRCALPHA
@@ -42,11 +43,11 @@ def test_conformance(test_name, test_func):
                        # Flag as pure white for easier visual inspection
                        diff_surf.set_at(point, (255, 255, 255, 255))
    if differences:
-       print ("conformance test %s FAILED.\n"
-              "  Difference saved to %s" % (test_name, diffname))
+       print("conformance test %s FAILED.\n"
+             "  Difference saved to %s" % (test_name, diffname))
        image.save(diff_surf, diffname)
    else:
-       print "conformance test %s passed" % test_name
+       print("conformance test %s passed" % test_name)
 
 
 def gen_test_image(test_name, test_func):
@@ -55,4 +56,4 @@ def gen_test_image(test_name, test_func):
    test_func(test_surf)
    imgname = 'results/gen_%s.png' % test_name
    image.save(test_surf, imgname)
-   print 'completed %s. Result saved to %s' % (test_name, imgname)
+   print('completed %s. Result saved to %s' % (test_name, imgname))

--- a/conformance/gen_conformance.py
+++ b/conformance/gen_conformance.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 
 from conf_tests import conformance_tests, gen_test_image
 import os

--- a/conformance/test_conformance.py
+++ b/conformance/test_conformance.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 
 from conf_tests import conformance_tests, test_conformance
 import os


### PR DESCRIPTION
Since it's sometimes useful to do this.