### PR TITLE
Bugs/issue 34 fix music endevent

### DIFF
--- a/pygame/event.py
+++ b/pygame/event.py
@@ -223,7 +223,7 @@ def post(event):
     check_video()
     is_blocked = sdl.SDL_EventState(event.type, sdl.SDL_QUERY) == sdl.SDL_IGNORE
     if is_blocked:
-        # Silently drop blocked events
+        # Silently drop blocked events, since that's what pygame does
         # (maybe worth logging somehow?)
         return None
 

--- a/pygame/event.py
+++ b/pygame/event.py
@@ -223,7 +223,9 @@ def post(event):
     check_video()
     is_blocked = sdl.SDL_EventState(event.type, sdl.SDL_QUERY) == sdl.SDL_IGNORE
     if is_blocked:
-        raise RuntimeError("event post blocked for %s" % event_name(event.type))
+        # Silently drop blocked events
+        # (maybe worth logging somehow?)
+        return None
 
     sdl_event = ffi.new("SDL_Event *")
     sdl_event.type = event.type

--- a/pygame/mixer.py
+++ b/pygame/mixer.py
@@ -576,7 +576,7 @@ def _endsound_callback(channelnum):
 
     data = _channeldata[channelnum]
     # post sound ending event
-    if data.endevent != sdl.SDL_NOEVENT and sdl.SDL_WasInit(sdl.SDL_INIT_AUDIO):
+    if data.endevent != sdl.SDL_NOEVENT and sdl.SDL_WasInit(sdl.SDL_INIT_VIDEO):
         event = ffi.new('SDL_Event*')
         event.type = data.endevent
         if event.type >= sdl.SDL_USEREVENT and event.type < sdl.SDL_NUMEVENTS:

--- a/pygame/mixer_music.py
+++ b/pygame/mixer_music.py
@@ -204,7 +204,12 @@ def queue(filename):
 def _endmusic_callback():
     global _current_music, _queue_music, _music_pos, _music_pos_time
     if _endmusic_event is not None and sdl.SDL_WasInit(sdl.SDL_INIT_AUDIO):
-        event.post(event.Event(_endmusic_event))
+        # Pygame doesn't do the same checks for this path as in
+        # event.post, and people rely on that, so we also duplicate
+        # the logic
+        event = ffi.new('SDL_Event*')
+        event.type = _endmusic_event
+        sdl.SDL_PushEvent(event)
 
     if _queue_music:
         if _current_music:

--- a/test/event_test.py
+++ b/test/event_test.py
@@ -94,7 +94,6 @@ class EventModuleTest(unittest.TestCase):
     def tearDown(self):
         pygame.display.quit()
 
-    @expected_error(RuntimeError)
     def test_set_blocked(self):
         # __doc__ (as of 2008-06-25) for pygame.event.set_blocked:
     


### PR DESCRIPTION
Pygame handling the 'end music event'  is a lot more forgiving than pygame_cffi's, since it doesn't use event.post. This changes the behavior to match.

Raising a RuntimeError for blocked events is also incorrect, since they should just silently dropped.