### PR TITLE
Bugs/issue 35 load stringio

### DIFF
--- a/pygame/image.py
+++ b/pygame/image.py
@@ -25,7 +25,7 @@ def load(filename, namehint=""):
             elif hasattr(filename, 'name'):
                 name, ext = path.splitext(filename.name)
             else:
-                # No name info, so we pass an empty extension
+                # No name info, so we pass an empty extension to
                 # SDL to indicate we can only load files with
                 # suitable magic format markers in the file.
                 name, ext = '', ''

--- a/pygame/image.py
+++ b/pygame/image.py
@@ -22,8 +22,13 @@ def load(filename, namehint=""):
             rwops = rwops_from_file(filename)
             if namehint:
                 name, ext = path.splitext(namehint)
-            else:
+            elif hasattr(filename, 'name'):
                 name, ext = path.splitext(filename.name)
+            else:
+                # No name info, so we pass an empty extension
+                # SDL to indicate we can only load files with
+                # suitable magic format markers in the file.
+                name, ext = '', ''
             if len(ext) == 0:
                 ext = name
             ext = rwops_encode_file_path(ext)

--- a/pygame/rwobject.py
+++ b/pygame/rwobject.py
@@ -13,7 +13,7 @@ def obj_seek(context, offset, whence):
         return -1
     # whence = 1 => SEEK_CUR, from python docs
     if offset != 0 or whence != 1:
-        # We're actually being call to do a seek
+        # We're actually being called to do a seek
         fileobj.seek(offset, whence)
     return fileobj.tell()
 
@@ -75,7 +75,7 @@ def rwops_from_file(fileobj):
         rwops = sdl.SDL_RWFromFP(fileobj, 0)
     except (TypeError, IOError):
         # Construct a suitable rwops object
-        rwops = sdl. SDL_AllocRW()
+        rwops = sdl.SDL_AllocRW()
         rwops.hidden.unknown.data1 = ffi.new_handle(fileobj)
         rwops.seek = obj_seek
         rwops.read = obj_read

--- a/pygame/rwobject.py
+++ b/pygame/rwobject.py
@@ -73,7 +73,7 @@ def rwops_from_file(fileobj):
         # We try use the SDL helper first, since
         # it's the simplest code path
         rwops = sdl.SDL_RWFromFP(fileobj, 0)
-    except TypeError:
+    except (TypeError, IOError):
         # Construct a suitable rwops object
         rwops = sdl. SDL_AllocRW()
         rwops.hidden.unknown.data1 = ffi.new_handle(fileobj)

--- a/pygame/rwobject.py
+++ b/pygame/rwobject.py
@@ -1,8 +1,60 @@
 """ The pygame rwobject module for IO using SDL_RWops """
 
-from pygame._sdl import sdl
+from pygame._sdl import ffi, sdl
 from pygame._error import SDLError
 from pygame.compat import bytes_, filesystem_encode, unicode_
+
+
+# Callback helpers for rwops_from_file
+@ffi.callback("int (SDL_RWops* context, int offset, int whence)")
+def obj_seek(context, offset, whence):
+    fileobj = ffi.from_handle(context.hidden.unknown.data1)
+    if not hasattr(fileobj, 'tell') or not hasattr(fileobj, 'seek'):
+        return -1
+    # whence = 1 => SEEK_CUR, from python docs
+    if offset != 0 or whence != 1:
+        # We're actually being call to do a seek
+        fileobj.seek(offset, whence)
+    return fileobj.tell()
+
+
+@ffi.callback("int (SDL_RWops* context, void* output, int size, int maxnum)")
+def obj_read(context, output, size, maxnum):
+    fileobj = ffi.from_handle(context.hidden.unknown.data1)
+    if not hasattr(fileobj, 'read'):
+        return -1
+    data = fileobj.read(size * maxnum)
+    if not data:
+        return -1
+    retval = len(data)
+    ffi.memmove(output, data, retval)
+    retval = retval // size
+    return retval
+
+
+@ffi.callback(
+    "int (SDL_RWops* context, const void* input, int size, int maxnum)")
+def obj_write(context, input, size, maxnum):
+    fileobj = ffi.from_handle(context.hidden.unknown.data1)
+    if not hasattr(fileobj, 'write'):
+        return -1
+    data = ffi.buffer(input, size*maxnum)
+    try:
+        fileobj.write(data)
+    except IOError:
+        return -1
+    return size*maxnum
+
+
+@ffi.callback("int (SDL_RWops* context)")
+def obj_close(context):
+    fileobj = ffi.from_handle(context.hidden.unknown.data1)
+    retval = 0
+    if hasattr(fileobj, 'close'):
+        if fileobj.close():
+            retval = -1
+    sdl.SDL_FreeRW(context)
+    return retval
 
 
 def rwops_encode_file_path(filepath):
@@ -17,7 +69,18 @@ def rwops_encode_file_path(filepath):
 
 
 def rwops_from_file(fileobj):
-    rwops = sdl.SDL_RWFromFP(fileobj, 0)
+    try:
+        # We try use the SDL helper first, since
+        # it's the simplest code path
+        rwops = sdl.SDL_RWFromFP(fileobj, 0)
+    except TypeError:
+        # Construct a suitable rwops object
+        rwops = sdl. SDL_AllocRW()
+        rwops.hidden.unknown.data1 = ffi.new_handle(fileobj)
+        rwops.seek = obj_seek
+        rwops.read = obj_read
+        rwops.write = obj_write
+        rwops.close = obj_close
     if not rwops:
         raise SDLError.from_sdl_error()
     return rwops

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -22,6 +22,7 @@ from pygame.compat import xrange_, ord_
 import os
 import array
 import tempfile
+from io import BytesIO
 
 def test_magic(f, magic_hex):
     """ tests a given file to see if the magic hex matches.
@@ -86,6 +87,23 @@ class ImageModuleTest( unittest.TestCase ):
         surf = pygame.image.load(f)
         f.close()
 
+        pixel_x0_y0 = surf.get_at((0, 0))
+        pixel_x1_y0 = surf.get_at((1, 0))
+        pixel_x0_y1 = surf.get_at((0, 1))
+        pixel_x1_y1 = surf.get_at((1, 1))
+
+        self.assertEquals(pixel_x0_y0, reddish_pixel)
+        self.assertEquals(pixel_x1_y0, greenish_pixel)
+        self.assertEquals(pixel_x0_y1, bluish_pixel)
+        self.assertEquals(pixel_x1_y1, greyish_pixel)
+
+        # Test that we can load it going via a BytesIO object
+
+        f = open(f_path, 'rb')
+        buf = BytesIO(f.read())
+        f.close()
+
+        surf = pygame.image.load(buf)
         pixel_x0_y0 = surf.get_at((0, 0))
         pixel_x1_y0 = surf.get_at((1, 0))
         pixel_x0_y1 = surf.get_at((0, 1))

--- a/test/imageext_test.py
+++ b/test/imageext_test.py
@@ -28,7 +28,6 @@ class ImageextModuleTest( unittest.TestCase ):
         im = pygame.Surface((10, 10), 0, 32)
         self.assertRaises(TypeError, save_extended, im, [])
 
-    @expected_error(TypeError)
     def test_load_non_string_file(self):
         self.assertRaises(pygame.error, load_extended, [])
 
@@ -37,7 +36,6 @@ class ImageextModuleTest( unittest.TestCase ):
         u = u"a\x00b\x00c.png"
         self.assertRaises(pygame.error, save_extended, im, u)
 
-    @expected_error(TypeError)
     def test_load_bad_filename(self):
         u = u"a\x00b\x00c.png"
         self.assertRaises(pygame.error, load_extended, u)


### PR DESCRIPTION
This adds support for loading images from file-like objects such as BytesIO.

This should close #35 

This implementation may break on windows, as noted in the FIXME in sdl_c_build.py. Since I'm not in a postiion to test possible workarounds, I've left this as something to be fixed later.
