### PR TITLE
Bugs/missing raises

### DIFF
--- a/pygame/color.py
+++ b/pygame/color.py
@@ -36,7 +36,7 @@ class Color(object):
             elif isinstance(arg, Color):
                 r, g, b, a = arg[:]
             else:
-                ValueError("invalid color argument")
+                raise ValueError("invalid color argument")
 
         elif len(args) == 4:
             r, g, b, a = args
@@ -44,7 +44,7 @@ class Color(object):
             r, g, b = args
             a = 255
         else:
-            ValueError("invalid color argument")
+            raise ValueError("invalid color argument")
 
         self._data = [0, 0, 0, 0]
         self._len = 4

--- a/pygame/joystick.py
+++ b/pygame/joystick.py
@@ -34,7 +34,7 @@ def init():
     Initialize the joystick module.
     """
     if not autoinit():
-        SDLError.from_sdl_error()
+        raise SDLError.from_sdl_error()
 
 
 def quit():

--- a/pygame/time.py
+++ b/pygame/time.py
@@ -141,7 +141,7 @@ def set_timer(eventid, milliseconds):
     handle = ffi.cast("void *", eventid)
     newtimer = sdl.SDL_AddTimer(milliseconds, _timer_callback, handle)
     if not newtimer:
-        SDLError.from_sdl_error()
+        raise SDLError.from_sdl_error()
 
     _event_timers[eventid] = newtimer
 

--- a/pygame/transform.py
+++ b/pygame/transform.py
@@ -19,7 +19,7 @@ def new_surface_from_surface(c_surface, w, h):
                                        format.Rmask, format.Gmask,
                                        format.Bmask, format.Amask)
     if not newsurf:
-        SDLError.from_sdl_error()
+        raise SDLError.from_sdl_error()
 
     if format.BytesPerPixel == 1 and format.palette:
         sdl.SDL_SetColors(newsurf, format.palette.colors, 0,


### PR DESCRIPTION
There are several places where we create an exception, without actually raising the error.

This is a bad idea, and leads to confusing errors when pygame eventually trips over the problem.