### PR TITLE
Bugs/color should support long

### DIFF
--- a/pygame/color.py
+++ b/pygame/color.py
@@ -1,7 +1,7 @@
 import string
 
 from pygame._sdl import ffi, sdl
-from pygame.compat import string_types
+from pygame.compat import string_types, long_
 import pygame.colordict
 
 
@@ -20,11 +20,11 @@ class Color(object):
 
         elif len(args) == 1:
             arg = args[0]
-            if isinstance(arg, int):
-                r = (arg >> 24) & 0xff
-                g = (arg >> 16) & 0xff
-                b = (arg >> 8) & 0xff
-                a = arg & 0xff
+            if isinstance(arg, int) or isinstance(arg, long_):
+                r = int((arg >> 24) & 0xff)
+                g = int((arg >> 16) & 0xff)
+                b = int((arg >> 8) & 0xff)
+                a = int(arg & 0xff)
             elif isinstance(arg, (tuple, list)):
                 if len(arg) == 4:
                     r, g, b, a = arg

--- a/pygame/color.py
+++ b/pygame/color.py
@@ -435,7 +435,7 @@ def _check_range(val):
 
 
 def create_color(color, color_format):
-    if isinstance(color, int):
+    if isinstance(color, int) or isinstance(color, long_):
         return color
     if isinstance(color, Color):
         return sdl.SDL_MapRGBA(color_format, color.r, color.g, color.b,

--- a/pygame/color.py
+++ b/pygame/color.py
@@ -20,7 +20,7 @@ class Color(object):
 
         elif len(args) == 1:
             arg = args[0]
-            if isinstance(arg, int) or isinstance(arg, long_):
+            if isinstance(arg, (int, long_)):
                 r = int((arg >> 24) & 0xff)
                 g = int((arg >> 16) & 0xff)
                 b = int((arg >> 8) & 0xff)
@@ -435,7 +435,7 @@ def _check_range(val):
 
 
 def create_color(color, color_format):
-    if isinstance(color, int) or isinstance(color, long_):
+    if isinstance(color, (int, long_)):
         return color
     if isinstance(color, Color):
         return sdl.SDL_MapRGBA(color_format, color.r, color.g, color.b,

--- a/test/color_test.py
+++ b/test/color_test.py
@@ -557,8 +557,8 @@ class ColorTypeTest (unittest.TestCase):
         self.assertRaises (ValueError, pygame.Color, "quarky")
 
     def test_int (self):
-        # This will be a long
-        c = pygame.Color (0xCC00CC00)
+        # This is a long
+        c = pygame.Color (long_(0xCC00CC00))
         self.assertEquals (c.r, 204)
         self.assertEquals (c.g, 0)
         self.assertEquals (c.b, 204)
@@ -574,8 +574,9 @@ class ColorTypeTest (unittest.TestCase):
         self.assertEquals (int (c), int (0x33727592))
 
     def test_long (self):
-        # This will be a long
-        c = pygame.Color (0xCC00CC00)
+        # This is a long on 32-bit, but an int on 64-bit, so
+        # we explicitly cast it to test the behaviour we want
+        c = pygame.Color (long_ (0xCC00CC00))
         self.assertEquals (c.r, 204)
         self.assertEquals (c.g, 0)
         self.assertEquals (c.b, 204)


### PR DESCRIPTION
pygame.color.Color() should allow a long as input on python 2.

The test suites claims to test that this works, but this is only true on 32-bit platforms, so fix that as well.