### PR TITLE
Add logic so we can test pypy using the version from the launchpad ppa

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,27 @@ python:
 - 3.4
 - 3.5
 - nightly
+- pypy
 # Not useable until PyPy 2.6 is available
-#- pypy
 #- pypy3
+# We force an overwrite of the virtualenv so we run the tests with the
+# pypy from the ppa
+before_install:
+   - |
+      if [ "$TRAVIS_PYTHON_VERSION" = "pypy" ]; then
+         VPATH=$VIRTUAL_ENV
+         deactivate
+         virtualenv -p /usr/bin/pypy $VPATH
+         source $VPATH/bin/activate
+      fi
+
 install: pip install -e .
 script: AUDIODEV=null xvfb-run python -m test
 sudo: false
 addons:
   apt:
+    sources:
+    - pypy
     packages:
     - libffi-dev
     - libjpeg-dev
@@ -21,4 +34,5 @@ addons:
     - libsdl-mixer1.2-dev
     - libsdl-ttf2.0-dev
     - libsdl1.2-dev
+    - pypy
     - xvfb


### PR DESCRIPTION
To address #42 , this uses the launchpad ppa to provide pypy and test with it.

It's not ideal, but until travis-ci supports a newer pypy natively, I don't think there's a better approach.

Given that there was a period when travis was not able to contact the ppa today, leading to strange failures, we may need to add additional checks to abort the test early if we fail to install a sufficiently recent pypy build, but I don't want to add that logic until we know if the problem will occur often enough to justify it.

This makes the build fail, since the test suite currently doesn't pass on pypy, but that is the point of adding pypy as a testing target.