### PR TITLE
Remove PyBytes_FromString test.

### DIFF
--- a/test/mixer_test.py
+++ b/test/mixer_test.py
@@ -514,21 +514,12 @@ class MixerModuleTest(unittest.TestCase):
                               buftools.PyBUF_F_CONTIGUOUS)
 
     def test_get_raw(self):
-        from ctypes import pythonapi, c_void_p, py_object
-
-        try:
-            Bytes_FromString = pythonapi.PyBytes_FromString
-        except:
-            Bytes_FromString = pythonapi.PyString_FromString
-        Bytes_FromString.restype = c_void_p
-        Bytes_FromString.argtypes = [py_object]
         mixer.init()
         try:
             samples = b'abcdefgh' # keep byte size a multiple of 4
             snd = mixer.Sound(buffer=samples)
             raw = snd.get_raw()
             self.assertTrue(isinstance(raw, bytes_))
-            self.assertNotEqual(snd._samples_address, Bytes_FromString(samples))
             self.assertEqual(raw, samples)
         finally:
             mixer.quit()


### PR DESCRIPTION
This test is meaningless on PyPy, and also doesn't test what it aims to test on CPython.

AFAICS, the test aims to check that the buffer is actually a copy of the string data passed in, rather than pointing to the same buffer. Hower, PyBytes_FromString will return the address of the surrounding PyObject,rather than the address of the actual string data, which is what the buffer would be pointing to if it were not a copy. Given that the assumptions of this test are very heavily tied to CPython internals, I see no value in fixing the test. It'd be much better to test that changing the sound buffer doesn't change the original object, which we can add if we ever implement anything to change the sound buffer.