### PR TITLE
Implement Rect.__new__

### DIFF
--- a/pygame/rect.py
+++ b/pygame/rect.py
@@ -14,6 +14,8 @@ class GameRect(object):
 class Rect(object):
 
     def __new__(cls, *args, **kwargs):
+        # Subclasses of Rect expect to be able to manipulate the values of the rect
+        # before calling Rect.__init__, so we ensure that self.r always exists.
         obj = super(Rect, cls).__new__(cls)
         obj.r =  GameRect(0, 0, 0, 0)
         return obj

--- a/pygame/rect.py
+++ b/pygame/rect.py
@@ -13,6 +13,11 @@ class GameRect(object):
 
 class Rect(object):
 
+    def __new__(cls, *args, **kwargs):
+        obj = super(Rect, cls).__new__(cls)
+        obj.r =  GameRect(0, 0, 0, 0)
+        return obj
+
     def __init__(self, *args):
         try:
             if len(args) == 1:

--- a/test/rect_test.py
+++ b/test/rect_test.py
@@ -16,6 +16,13 @@ else:
     from test.test_utils import test_not_implemented, unittest
 from pygame import Rect
 
+
+class SubRect1(Rect):
+    def __init__(self):
+        self.topleft = (50, 50)
+        self.w = 100
+        self.h = 10
+
 class RectTypeTest( unittest.TestCase ):
     def testConstructionXYWidthHeight( self ):
         r = Rect(1,2,3,4)
@@ -668,6 +675,11 @@ class RectTypeTest( unittest.TestCase ):
         r = Rect(1, 2, 10, 20)
         c = r.copy()
         self.failUnlessEqual(c, r)
-        
+
+    def test_subrect(self):
+        r = SubRect1()
+        self.assertEqual(r, Rect(50, 50, 100, 10))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
As observed with testing pygame-zero with pygame-cffi, we need pygame.Rect.__new__ to create the initial rect so subclasses can maniuplate it before calling pygame.Rect.__init__ .

