### PR TITLE
Bugs/bump cffi requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ There is also the #pygame-cffi channel on irc.freenode.net
 
 ## Requirements
 
+pygame_cffi requires a recent version of python-cffi to build (at least
+version 1.3.0).
+
 * libjpeg-dev
 * libpng-dev
 * libsdl1.2-dev

--- a/setup.py
+++ b/setup.py
@@ -28,11 +28,11 @@ setup(
     scripts=[
     ],
     setup_requires=[
-        'cffi>=1.0.3',
+        'cffi>=1.3.0',
     ],
     cffi_modules=cffi_modules,
     install_requires=[
-        'cffi>=1.0.3',
+        'cffi>=1.3.0',
     ],
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
We need cffi 1.3.0 or later to build the RWops callbacks correctly (See recent IRC reports of issues with using the cffi version in Ubuntu wily). This updates the requirements and docs to reflect that.