### PR TITLE
Bugs/fix pygame smoothscale crash

### DIFF
--- a/conformance/conf_tests/__init__.py
+++ b/conformance/conf_tests/__init__.py
@@ -17,7 +17,8 @@ from .test_blending import (test_rgba_add, test_rgba_sub, test_rgba_min,
                             test_rgba_max, test_rgba_mult, test_rgb_mult,
                             test_blend_mult)
 from .test_smoothscale import (test_int_smoothscale, test_x_smoothscale,
-                               test_y_smoothscale, test_varied_smoothscale)
+                               test_y_smoothscale, test_varied_smoothscale,
+                               test_subsurface_smoothscale)
 
 conformance_tests = {
     'test_rgba_add': test_rgba_add,
@@ -44,6 +45,7 @@ conformance_tests = {
     'smooth_x': test_x_smoothscale,
     'smooth_y': test_y_smoothscale,
     'smooth_varies': test_varied_smoothscale,
+    'smooth_subsurface': test_subsurface_smoothscale,
     'chop': test_chop,
     'rotozoom': test_rotozoom,
     'hollow_circles': test_hollow_circles,

--- a/conformance/conf_tests/test_smoothscale.py
+++ b/conformance/conf_tests/test_smoothscale.py
@@ -14,7 +14,7 @@ def _make_object():
 
 
 def test_subsurface_smoothscale(surface):
-    """Simple integer scaling tests"""
+    """Test scaling a small subsurface"""
     obj = _make_object()
 
     transform.set_smoothscale_backend('GENERIC')

--- a/conformance/conf_tests/test_smoothscale.py
+++ b/conformance/conf_tests/test_smoothscale.py
@@ -13,6 +13,28 @@ def _make_object():
     return obj
 
 
+def test_subsurface_smoothscale(surface):
+    """Simple integer scaling tests"""
+    obj = _make_object()
+
+    transform.set_smoothscale_backend('GENERIC')
+
+    obj_sub = obj.subsurface((20, 20, 20, 25))
+
+    surface.blit(obj, (20, 20))
+    surface.blit(obj_sub, (60, 20))
+    obj1 = transform.smoothscale(obj_sub, (obj_sub.get_width(), obj_sub.get_height()))
+    surface.blit(obj1, (120, 20))
+    obj1 = transform.smoothscale(obj_sub, (20, 20))
+    surface.blit(obj1, (60, 60))
+    obj1 = transform.smoothscale(obj_sub, (40, 40))
+    surface.blit(obj1, (80, 80))
+    obj1 = transform.smoothscale(obj_sub, (60, 60))
+    surface.blit(obj1, (160, 160))
+    obj1 = transform.smoothscale(obj_sub, (120, 120))
+    surface.blit(obj1, (220, 220))
+
+
 def test_int_smoothscale(surface):
     """Simple integer scaling tests"""
     obj = _make_object()
@@ -20,6 +42,8 @@ def test_int_smoothscale(surface):
     transform.set_smoothscale_backend('GENERIC')
 
     surface.blit(obj, (20, 20))
+    obj1 = transform.smoothscale(obj, (obj.get_width(), obj.get_height()))
+    surface.blit(obj1, (120, 20))
     obj1 = transform.smoothscale(obj, (20, 20))
     surface.blit(obj1, (60, 60))
     obj1 = transform.smoothscale(obj, (40, 40))

--- a/pygame/transform.py
+++ b/pygame/transform.py
@@ -241,11 +241,16 @@ def smoothscale(surface, size, dest_surface=None):
         with locked(new_surf):
             with locked(c_surf):
                 if c_surf.w == width and c_surf.h == height:
-                    pitch = c_surf.pitch
+                    c_pitch = c_surf.pitch
+                    n_pitch = new_surf.pitch
                     # Trivial case
                     srcpixels = ffi.cast('uint8_t*', c_surf.pixels)
                     destpixels = ffi.cast('uint8_t*', new_surf.pixels)
-                    destpixels[0:height * pitch] = srcpixels[0:height * pitch]
+                    step = width * bpp
+                    for y in range(0, height):
+                        offset_n = y * n_pitch
+                        offset_c = y * c_pitch
+                        destpixels[offset_n:offset_n + step] = srcpixels[offset_c:offset_c + step]
                 else:
                     sdl.scalesmooth(c_surf, new_surf)
     if dest_surface:

--- a/pygame/transform.py
+++ b/pygame/transform.py
@@ -241,9 +241,9 @@ def smoothscale(surface, size, dest_surface=None):
         with locked(new_surf):
             with locked(c_surf):
                 if c_surf.w == width and c_surf.h == height:
+                    # Non-scaling case, so just copy the correct pixels
                     c_pitch = c_surf.pitch
                     n_pitch = new_surf.pitch
-                    # Trivial case
                     srcpixels = ffi.cast('uint8_t*', c_surf.pixels)
                     destpixels = ffi.cast('uint8_t*', new_surf.pixels)
                     step = width * bpp


### PR DESCRIPTION
As reported on irc, smoothscale can cause a crash in certain circumstances.

This fixes the obvious error and ads a conformance test for that case to ensure we're matching pygame's behaviour.

Similiar issues probably lurk in other places in pygame.transform - we should examine that closely in the not too distant future.

