### PR TITLE
Include fonts and images from the pygame package in builds.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,7 @@ include README.md
 include setup.py
 
 recursive-include cffi_builders *
+recursive-include pygame *.ttf *.bmp *.icns *.svg *.tiff
 
 # Prune stray bytecode files.
 global-exclude *.pyc


### PR DESCRIPTION
As described in #57, currently they are not included.