### PR TITLE
Expose THECOLORS to color.py

### DIFF
--- a/pygame/color.py
+++ b/pygame/color.py
@@ -4,6 +4,8 @@ from pygame._sdl import ffi, sdl
 from pygame.compat import string_types, long_
 import pygame.colordict
 
+# Some games take colors from pygame.color.THECOLORS dict
+THECOLORS = pygame.colordict.THECOLORS
 
 class Color(object):
     def __init__(self, *args):


### PR DESCRIPTION
Expose THECOLORS to color.py, since some games use pygame.color.THECOLORS and pygame exposes THECOLORS in the same way:
pygame_cffi:
```
>>> pygame.color.THECOLORS
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'module' object has no attribute 'THECOLORS'
```

pygame:
```
>>> import pygame
>>> pygame.color.THECOLORS
{'maroon4': (139, 28, 98, 255), 'gold': (255, 215, 0, 255), 'dodgerblue3': (24, 116...long list of colors)
```