### PR TITLE
Bugs/issue 68 int 16 too small

### DIFF
--- a/conformance/conf_tests/__init__.py
+++ b/conformance/conf_tests/__init__.py
@@ -12,7 +12,8 @@ from .test_transforms import (test_flip, test_scale, test_rotate, test_chop,
                               test_chop_subsurface)
 from .test_shapes import (test_rect, test_polygon, test_hollow_circles,
                           test_filled_circles, test_filled_ellipses_1,
-                          test_filled_ellipses_2, test_hollow_ellipses)
+                          test_filled_ellipses_2, test_hollow_ellipses,
+                          test_filled_circles_limits)
 from .test_surface import test_scroll
 from .test_blending import (test_rgba_add, test_rgba_sub, test_rgba_min,
                             test_rgba_max, test_rgba_mult, test_rgb_mult,
@@ -56,6 +57,7 @@ conformance_tests = {
     'filled_ellipses_1': test_filled_ellipses_1,
     'filled_ellipses_2': test_filled_ellipses_2,
     'hollow_ellipses': test_hollow_ellipses,
+    'limit_circles': test_filled_circles_limits,
 }
 
 

--- a/conformance/conf_tests/test_shapes.py
+++ b/conformance/conf_tests/test_shapes.py
@@ -116,3 +116,20 @@ def test_hollow_ellipses(test_surf):
                           2 * r1, 2 * r2)
                 draw.ellipse(test_surf, color, e_rect, thickness)
 
+def test_filled_circles_limits(test_surf):
+    """Draw several filled circles that wrap the limits in various ways"""
+    for cent_x, color in ((100, (0, 0, 255, 255)), (400, (0, 255, 255, 255)),
+                          (600, (255, 0, 255, 255))):
+        cent_y = 10
+        for radius in range(10,100,10):
+            cent_y += radius + 1
+            o_x = 2**16 + cent_x
+            o_y = 2**16 + cent_y
+            # This should appear
+            draw.circle(test_surf, color, (o_x, o_y),
+                        radius)
+            # This shouldn't appear, but not crash
+            o_x = 2**15 + cent_x
+            o_y = 2**17 + cent_x
+            draw.circle(test_surf, color, (o_x, o_y),
+                        radius)

--- a/pygame/draw.py
+++ b/pygame/draw.py
@@ -48,7 +48,7 @@ def _make_drawn_rect(points, surface):
     right = min(rect.right, max(p[0] for p in points))
     top = max(rect.top, min(p[1] for p in points))
     bottom = min(rect.bottom, max(p[1] for p in points))
-    return Rect(left, top, right - left + 1, bottom - top + 1)
+    return Rect(left, top, max(right - left + 1, 0), max(bottom - top + 1, 0))
 
 
 _CLIP_LEFT = 1

--- a/pygame/draw.py
+++ b/pygame/draw.py
@@ -595,6 +595,12 @@ def _fillellipse(surface, pos, radius_x, radius_y, color):
 
 def _check_special_ellipse(surface, c_x, c_y, radius_x, radius_y, c_color):
     if radius_x == 0 and radius_y == 0:
+        clip = surface.get_clip()
+        # Throw away points outside the clip area
+        if c_x < clip.x or c_x > (clip.x + clip.w):
+            return True
+        if c_y < clip.y or c_y > (clip.y + clip.h):
+            return True
         with locked(surface._c_surface):
             surface._set_at(c_x, c_y, c_color)
         return True

--- a/pygame/draw.py
+++ b/pygame/draw.py
@@ -124,9 +124,9 @@ def _drawhorizline(surface, c_color, start_x, end_x, y):
     sdlrect = ffi.new('SDL_Rect*')
     if start_x > end_x:
         end_x, start_x = start_x, end_x
-    sdlrect.x = start_x
-    sdlrect.y = y
-    sdlrect.w = end_x - start_x + 1
+    sdlrect.x = ffi.cast("int16_t",start_x)
+    sdlrect.y = ffi.cast("int16_t", y)
+    sdlrect.w = ffi.cast("uint16_t", end_x - start_x + 1)
     sdlrect.h = 1
     sdl.SDL_FillRect(surface._c_surface, sdlrect, c_color)
 
@@ -136,10 +136,10 @@ def _drawvertline(surface, c_color, start_y, end_y, x):
     sdlrect = ffi.new('SDL_Rect*')
     if start_y > end_y:
         end_y, start_y = start_y, end_y
-    sdlrect.x = x
-    sdlrect.y = start_y
+    sdlrect.x = ffi.cast("int16_t", x)
+    sdlrect.y = ffi.cast("int16_t", start_y)
     sdlrect.w = 1
-    sdlrect.h = end_y - start_y + 1
+    sdlrect.h = ffi.cast("uint16_t", end_y - start_y + 1)
     sdl.SDL_FillRect(surface._c_surface, sdlrect, c_color)
 
 

--- a/pygame/draw.py
+++ b/pygame/draw.py
@@ -124,7 +124,7 @@ def _drawhorizline(surface, c_color, start_x, end_x, y):
     sdlrect = ffi.new('SDL_Rect*')
     if start_x > end_x:
         end_x, start_x = start_x, end_x
-    sdlrect.x = ffi.cast("int16_t",start_x)
+    sdlrect.x = ffi.cast("int16_t", start_x)
     sdlrect.y = ffi.cast("int16_t", y)
     sdlrect.w = ffi.cast("uint16_t", end_x - start_x + 1)
     sdlrect.h = 1

--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -211,6 +211,27 @@ class DrawModuleTest(unittest.TestCase):
 
         self.fail() 
 
+
+    def test_circle_limits(self):
+        # Test that we don't crash on inputs greater than int16_t
+        # Correctness is not tested
+        screen = pygame.display.set_mode((100, 50))
+        r = draw.circle(screen, (0, 0, 0), (((2**16)//2)-1, 0), 0)
+        self.assertEqual(r.x, 32767)
+        self.assertEqual(r.y, 0)
+        self.assertEqual(r.w, 0)
+        r = draw.circle(screen, (0xff, 0xff, 0xff), (((2**16)//2), (2**16)//2), 0)
+        self.assertEqual(r.x, 32768)
+        self.assertEqual(r.y, 32768)
+        self.assertEqual(r.w, 0)
+
+        r = draw.circle(screen, (0xff, 0xff, 0xff), (((2**16)//2 + 1),
+                                                     ((2**16)//2 + 1)), 0)
+        self.assertEqual(r.x, 32769)
+        self.assertEqual(r.y, 32769)
+        self.assertEqual(r.w, 0)
+
+
     def todo_test_ellipse(self):
 
         # __doc__ (as of 2008-08-02) for pygame.draw.ellipse:


### PR DESCRIPTION
This should fix #68 

We're not completely pygame compatible, since we handle values greater than 2**32  differently. I hope the chances of anyone depending on that behaviour are small that we can ignore that, becuase matching that behaviour will be ugly.