### PR TITLE
Feature/enable appveyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ version 1.3.0).
 
 ## Building on windows
 
-To build on windows, you need to download the appropriate dependancy libraries.
+To build on windows, you need to download the appropriate dependency libraries.
 The ``pygame`` project provides all the required libraries in a nicely
 bundled set, available from `https://bitbucket.org/llindstrom/pygame/downloads/`
 

--- a/README.md
+++ b/README.md
@@ -48,3 +48,18 @@ version 1.3.0).
    argument.
 * Conformance between pygame and pygame_cffi: See `conformance/README`
 * pygame_cffi functionality example apps are in the `demos` directory
+
+
+## Building on windows
+
+To build on windows, you need to download the appropriate dependancy libraries.
+The ``pygame`` project provides all the required libraries in a nicely
+bundled set, available from `https://bitbucket.org/llindstrom/pygame/downloads/`
+
+For 32 bit machines, download the latest prebuilt-x86 zipfile and
+unzip it under the pygame_cffi directory.
+
+For 64 bit machines, download the latest prebuild-x64 zipfile and
+unzip it under the pygame_cffi directory.
+
+Then run python setup.py build to compile the modules.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://img.shields.io/travis/CTPUG/pygame_cffi.svg)](https://travis-ci.org/CTPUG/pygame_cffi)
 [![PyPI](https://img.shields.io/pypi/v/pygame_cffi.svg)](https://pypi.python.org/pypi/pygame_cffi)
+[![Windows Build status](https://ci.appveyor.com/api/projects/status/qsa3c9qfa8xt8j9i/branch/master?svg=true)](https://ci.appveyor.com/project/CTPUG/pygame-cffi/branch/master)
+
 
 A cffi-based SDL wrapper that copies the pygame API.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,9 +40,10 @@ install:
   - "powershell appveyor\\install.ps1"
   - "pip install -e ."
   - ps: "ls"
-  #- ps: "ls dist"
   - "powershell appveyor\\copydlls.ps1"
   - ps: "ls pygame"
+  - "python setup.py bdist_wheel"
+  - ps: "ls dist"
 
 
 # Appveyor's build step is specific to .NET projects, so we build in the

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,37 +1,34 @@
 environment:
 
+  global:
+     SDL_VIDEODRIVER: "dummy"
+     SDL_AUDIODRIVER: "disk"
+
+
   matrix:
     - PYTHON: "C:\\Python27"
       PYTHON_ARCH: "32"
-      AUDIODEV: "null"
 
     - PYTHON: "C:\\Python34"
       PYTHON_ARCH: "32"
-      AUDIODEV: "null"
 
     - PYTHON: "C:\\Python35"
       PYTHON_ARCH: "32"
-      AUDIODEV: "null"
 
     - PYTHON: "C:\\Python36"
       PYTHON_ARCH: "32"
-      AUDIODEV: "null"
 
     - PYTHON: "C:\\Python27-x64"
       PYTHON_ARCH: "64"
-      AUDIODEV: "null"
 
     - PYTHON: "C:\\Python34-x64"
       PYTHON_ARCH: "64"
-      AUDIODEV: "null"
 
     - PYTHON: "C:\\Python35-x64"
       PYTHON_ARCH: "64"
-      AUDIODEV: "null"
 
     - PYTHON: "C:\\Python36-x64"
       PYTHON_ARCH: "64"
-      AUDIODEV: "null"
 
 init:
   - "ECHO %PYTHON% %PYTHON_ARCH%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,56 @@
+environment:
+
+  matrix:
+    - PYTHON: "C:\\Python27"
+      PYTHON_ARCH: "32"
+      AUDIODEV: "null"
+
+    - PYTHON: "C:\\Python34"
+      PYTHON_ARCH: "32"
+      AUDIODEV: "null"
+
+    - PYTHON: "C:\\Python35"
+      PYTHON_ARCH: "32"
+      AUDIODEV: "null"
+
+    - PYTHON: "C:\\Python36"
+      PYTHON_ARCH: "32"
+      AUDIODEV: "null"
+
+    - PYTHON: "C:\\Python27-x64"
+      PYTHON_ARCH: "64"
+      AUDIODEV: "null"
+
+    - PYTHON: "C:\\Python34-x64"
+      PYTHON_ARCH: "64"
+      AUDIODEV: "null"
+
+    - PYTHON: "C:\\Python35-x64"
+      PYTHON_ARCH: "64"
+      AUDIODEV: "null"
+
+    - PYTHON: "C:\\Python36-x64"
+      PYTHON_ARCH: "64"
+      AUDIODEV: "null"
+
+init:
+  - "ECHO %PYTHON% %PYTHON_ARCH%"
+
+install:
+  # Ensure we use the right python version
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - "python --version"
+  - "powershell appveyor\\install.ps1"
+  - "pip install -e ."
+  - ps: "ls dist"
+  - ps: "ls "
+
+# Appveyor's build step is specific to .NET projects, so we build in the
+# install step instead.
+build: false
+
+test_script:
+  - "python -m test"
+
+#artifacts:
+#  - path: dist\*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,8 +42,11 @@ install:
   - "python --version"
   - "powershell appveyor\\install.ps1"
   - "pip install -e ."
-  - ps: "ls dist"
-  - ps: "ls "
+  - ps: "ls"
+  #- ps: "ls dist"
+  - "powershell appveyor\\copydlls.ps1"
+  - ps: "ls pygame"
+
 
 # Appveyor's build step is specific to .NET projects, so we build in the
 # install step instead.

--- a/appveyor/README.rst
+++ b/appveyor/README.rst
@@ -1,3 +1,4 @@
-Appveyor is a service we use to build windows binaries for pygame_cffi.
+Appveyor is a service we use to run continuous integration tests for
+pygame_cffi on windows and to build windows binaries for pygame_cffi.
 
-We borrow varioys helpers, like the install.psi script, from the pygame project.
+We borrow various helpers, like the install.ps1 script, from the pygame project.

--- a/appveyor/README.rst
+++ b/appveyor/README.rst
@@ -1,0 +1,3 @@
+Appveyor is a service we use to build windows binaries for pygame_cffi.
+
+We borrow varioys helpers, like the install.psi script, from the pygame project.

--- a/appveyor/copydlls.ps1
+++ b/appveyor/copydlls.ps1
@@ -1,0 +1,22 @@
+function CopyPrebuiltDLLs () {
+    $target = "x86"
+    if ($env:PYTHON_ARCH -eq "64") {
+        $target = "x64"
+    }
+    $prebuilt_dir = "prebuilt-"+$target
+
+    $basedir = $pwd.Path + "\"
+    $dlls = $basedir + $prebuilt_dir + "\lib\" + "*.dll"
+    $destpath = $basedir + "pygame"
+
+    Write-Host "dlls from" $dlls
+    Write-Host "destiation" $destpath
+
+    Copy-item $dlls -destination $destpath
+}
+
+function main () {
+    CopyPrebuiltDLLs
+}
+
+main

--- a/appveyor/copydlls.ps1
+++ b/appveyor/copydlls.ps1
@@ -10,7 +10,7 @@ function CopyPrebuiltDLLs () {
     $destpath = $basedir + "pygame"
 
     Write-Host "dlls from" $dlls
-    Write-Host "destiation" $destpath
+    Write-Host "destination" $destpath
 
     Copy-item $dlls -destination $destpath
 }

--- a/appveyor/install.ps1
+++ b/appveyor/install.ps1
@@ -1,0 +1,49 @@
+function InstallPackage ($python_home, $pkg) {
+    $pip_path = $python_home + "/Scripts/pip.exe"
+    & $pip_path install $pkg
+}
+
+function DownloadPrebuilt () {
+    $webclient = New-Object System.Net.WebClient
+
+    $download_url = "https://bitbucket.org/llindstrom/pygame/downloads/"
+    $build_date = "20150922"
+    $target = "x86"
+    if ($env:PYTHON_ARCH -eq "64") {
+        $target = "x64"
+    }
+    $prebuilt_file = "prebuilt-"+$target+"-pygame-1.9.2-"+$build_date+".zip"
+    $prebuilt_url = $download_url + $prebuilt_file
+    $prebuilt_zip = "prebuilt-" + $target + ".zip"
+
+    $basedir = $pwd.Path + "\"
+    $filepath = $basedir + $prebuilt_zip
+    if (Test-Path $filepath) {
+        Write-Host "Reusing" $filepath
+        return $filepath
+    }
+
+    # Download and retry up to 5 times in case of network transient errors.
+    Write-Host "Downloading" $filename "from" $prebuilt_url
+    $retry_attempts = 3
+    for($i=0; $i -lt $retry_attempts; $i++){
+        try {
+            $webclient.DownloadFile($prebuilt_url, $filepath)
+            break
+        }
+        Catch [Exception]{
+            Start-Sleep 1
+        }
+   }
+   Write-Host "File saved at" $filepath
+
+   & 7z x $prebuilt_zip
+}
+
+
+function main () {
+    InstallPackage $env:PYTHON wheel
+    & DownloadPrebuilt
+}
+
+main

--- a/cffi_builders/jpg_c_build.py
+++ b/cffi_builders/jpg_c_build.py
@@ -1,5 +1,6 @@
-
 import cffi
+from helpers import get_inc_dir, get_lib_dir
+
 
 ffi = cffi.FFI()
 
@@ -12,9 +13,13 @@ int write_jpeg (const char *file_name, unsigned char** image_buffer,
 
 """)
 
+
+
 jpglib = ffi.set_source(
     "pygame._jpg_c",
     libraries=['jpeg'],
+    include_dirs=get_inc_dir(),
+    library_dirs=get_lib_dir(),
     source="""
     #include <stdlib.h>
     #include <jpeglib.h>

--- a/cffi_builders/png_c_build.py
+++ b/cffi_builders/png_c_build.py
@@ -1,5 +1,6 @@
-
 import cffi
+from helpers import get_inc_dir, get_lib_dir
+
 
 ffi = cffi.FFI()
 
@@ -20,6 +21,8 @@ static int write_png(const char *file_name, unsigned char **rows, int w, int h,
 pnglib = ffi.set_source(
     "pygame._png_c",
     libraries=['png'],
+    include_dirs=get_inc_dir(),
+    library_dirs=get_lib_dir(),
     source="""
     #define PNG_SKIP_SETJMP_CHECK 1
     #include <stdlib.h>

--- a/cffi_builders/sdl_c_build.py
+++ b/cffi_builders/sdl_c_build.py
@@ -1,13 +1,5 @@
-import os
 import cffi
-
-
-def _get_c_lib(name):
-    """Return the contents of a C library."""
-    filename = os.path.join(
-        os.path.dirname(__file__), 'lib', name)
-    with open(filename) as lib:
-        return lib.read()
+from helpers import get_inc_dir, get_lib_dir, get_c_lib
 
 
 ffi = cffi.FFI()
@@ -718,7 +710,8 @@ int internal_get_bounding_rects(bitmask_t *input, int *num_bounding_boxes, SDL_R
 sdl = ffi.set_source(
     "pygame._sdl_c",
     libraries=['SDL', 'SDL_image', 'SDL_ttf', 'SDL_mixer'],
-    include_dirs=['/usr/include/SDL', '/usr/local/include/SDL'],
+    include_dirs=get_inc_dir(),
+    library_dirs=get_lib_dir(),
     source="""
     #include <stdlib.h>
     #include <SDL.h>
@@ -1014,16 +1007,16 @@ sdl = ffi.set_source(
 
     %(bitmask)s
     """ % {
-        'surface_h': _get_c_lib('surface.h'),
-        'bitmask_h': _get_c_lib('bitmask.h'),
-        'alphablit': _get_c_lib('alphablit.c'),
-        'surface_fill': _get_c_lib('surface_fill.c'),
-        'scale2x': _get_c_lib('scale2x.c'),
-        'rotate': _get_c_lib('rotate.c'),
-        'stretch': _get_c_lib('stretch.c'),
-        'smoothscale': _get_c_lib('smoothscale.c'),
-        'rotozoom': _get_c_lib('rotozoom.c'),
-        'bitmask': _get_c_lib('bitmask.c'),
+        'surface_h': get_c_lib('surface.h'),
+        'bitmask_h': get_c_lib('bitmask.h'),
+        'alphablit': get_c_lib('alphablit.c'),
+        'surface_fill': get_c_lib('surface_fill.c'),
+        'scale2x': get_c_lib('scale2x.c'),
+        'rotate': get_c_lib('rotate.c'),
+        'stretch': get_c_lib('stretch.c'),
+        'smoothscale': get_c_lib('smoothscale.c'),
+        'rotozoom': get_c_lib('rotozoom.c'),
+        'bitmask': get_c_lib('bitmask.c'),
     }
 )
 

--- a/cffi_builders/sdl_keys_c_build.py
+++ b/cffi_builders/sdl_keys_c_build.py
@@ -6,6 +6,7 @@ changed the cdef and have to rebuild.
 """
 
 import cffi
+from helpers import get_inc_dir
 
 ffi = cffi.FFI()
 
@@ -273,7 +274,7 @@ typedef enum {
 
 _sdl_keys = ffi.set_source(
     "pygame._sdl_keys_c",
-    include_dirs=['/usr/include/SDL', '/usr/local/include/SDL'],
+    include_dirs=get_inc_dir(),
     source="""
     #include <SDL_keysym.h>
     """

--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import platform
+
+# Various helpers for the build scripts
+
+def get_lib_dir():
+    if sys.platform.startswith("win"):
+        if platform.architecture()[0] == '32bit':
+            # 32 bit
+            return ['prebuilt-x86/lib']
+        else:
+            # 64 bit
+            return ['prebuilt-x64/lib']
+    return ['/usr/lib']
+
+
+def get_inc_dir():
+    if sys.platform.startswith("win"):
+        if platform.architecture()[0] == '32bit':
+            # 32 bit
+            return ['prebuilt-x86/include', 'prebuilt-x86/include/SDL']
+        else:
+            return ['prebuilt-x64/include', 'prebuilt-x64/include/SDL']
+    return ['/usr/include', '/usr/include/SDL', '/usr/local/include/SDL']
+
+def get_c_lib(name):
+    """Return the contents of a C library."""
+    filename = os.path.join(
+        os.path.dirname(__file__), '..', 'cffi_builders', 'lib', name)
+    with open(filename) as lib:
+        return lib.read()
+
+
+__all__ = [get_inc_dir, get_lib_dir, get_c_lib]

--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -5,6 +5,9 @@ import platform
 # Various helpers for the build scripts
 
 def get_lib_dir():
+    """Return the library path for SDL and other libraries.
+
+       Assumes we're using the pygame prebuilt zipfile on windows"""
     if sys.platform.startswith("win"):
         if platform.architecture()[0] == '32bit':
             # 32 bit
@@ -12,10 +15,13 @@ def get_lib_dir():
         else:
             # 64 bit
             return ['prebuilt-x64/lib']
-    return ['/usr/lib']
+    return ['/usr/lib','/usr/local/lib']
 
 
 def get_inc_dir():
+    """Return the include directories for the SDL and other libraries.
+
+       Assumes we're using the pygame prebuilt zipfile on windows"""
     if sys.platform.startswith("win"):
         if platform.architecture()[0] == '32bit':
             # 32 bit
@@ -23,6 +29,7 @@ def get_inc_dir():
         else:
             return ['prebuilt-x64/include', 'prebuilt-x64/include/SDL']
     return ['/usr/include', '/usr/include/SDL', '/usr/local/include/SDL']
+
 
 def get_c_lib(name):
     """Return the contents of a C library."""


### PR DESCRIPTION
This adds appveyor support for testing pygame_cffi on windows.

A number of tests faill, at least partly because RWops isn't correct on windows platforms, but at least the tests run.