### PR TITLE
Unbreak the pypy tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ before_install:
       if [ "$TRAVIS_PYTHON_VERSION" = "pypy" ]; then
          VPATH=$VIRTUAL_ENV
          deactivate
+         # The old files break pip, so get rid of them
+         rm -rf $VPATH/lib-python $VPATH/bin
          virtualenv -p /usr/bin/pypy $VPATH
          source $VPATH/bin/activate
       fi


### PR DESCRIPTION
With the latest version of pypy from the launchpad PPA, travis
fails when recreating the virtualenv. We brute-force remove
some of the old virtualenv to sidestep the issue.