### PR TITLE
Skip some tests that will fail due to appveyor environment, rather than broken code

### DIFF
--- a/test/event_test.py
+++ b/test/event_test.py
@@ -1,8 +1,9 @@
 #################################### IMPORTS ###################################
 
+import os
+
 if __name__ == '__main__':
     import sys
-    import os
     pkg_dir = os.path.split(os.path.abspath(__file__))[0]
     parent_dir, pkg_name = os.path.split(pkg_dir)
     is_pygame_pkg = (pkg_name == 'tests' and
@@ -240,6 +241,10 @@ class EventModuleTest(unittest.TestCase):
 
           # pygame.event.set_grab(bool): return None
           # control the sharing of input devices with other applications
+
+        # Skip the test if we don't have a display
+        if os.environ.get('SDL_VIDEODRIVER') == 'dummy':
+            return
 
         pygame.event.set_grab(True)
         self.assert_(pygame.event.get_grab())

--- a/test/font_test.py
+++ b/test/font_test.py
@@ -185,7 +185,7 @@ class FontTest(unittest.TestCase):
         # If we don't have a real display, don't do this test.
         # Transparent background doesn't seem to work without a read video card.
         # (:99 is a way to detect xvfb)
-        if os.environ.get('DISPLAY') != ':99':
+        if os.environ.get('DISPLAY') != ':99' and os.environ.get('SDL_VIDEODRIVER') != 'dummy':
             screen.fill((10, 10, 10))
             font_surface = f.render("   bar", True, (0, 0, 0), None)
             font_rect = font_surface.get_rect()


### PR DESCRIPTION
Not all the tests we currently run on appveyor are sensible there. This skips a couple of tests that will always fail. These tests are also skipped in pygame's test runs.