### PR TITLE
Fix failures in draw test

### DIFF
--- a/test/draw_test.py
+++ b/test/draw_test.py
@@ -215,18 +215,17 @@ class DrawModuleTest(unittest.TestCase):
     def test_circle_limits(self):
         # Test that we don't crash on inputs greater than int16_t
         # Correctness is not tested
-        screen = pygame.display.set_mode((100, 50))
-        r = draw.circle(screen, (0, 0, 0), (((2**16)//2)-1, 0), 0)
+        r = draw.circle(self.surf, (0, 0, 0), (((2**16)//2)-1, 0), 0)
         self.assertEqual(r.x, 32767)
         self.assertEqual(r.y, 0)
         self.assertEqual(r.w, 0)
-        r = draw.circle(screen, (0xff, 0xff, 0xff), (((2**16)//2), (2**16)//2), 0)
+        r = draw.circle(self.surf, (0xff, 0xff, 0xff), (((2**16)//2), (2**16)//2), 0)
         self.assertEqual(r.x, 32768)
         self.assertEqual(r.y, 32768)
         self.assertEqual(r.w, 0)
 
-        r = draw.circle(screen, (0xff, 0xff, 0xff), (((2**16)//2 + 1),
-                                                     ((2**16)//2 + 1)), 0)
+        r = draw.circle(self.surf, (0xff, 0xff, 0xff), (((2**16)//2 + 1),
+                                                        ((2**16)//2 + 1)), 0)
         self.assertEqual(r.x, 32769)
         self.assertEqual(r.y, 32769)
         self.assertEqual(r.w, 0)


### PR DESCRIPTION
Draw tests run after `test_circle_limits` were failing because subsequent `Surface` constructor calls got back an 8 bpp surface, from `sdl.SDL_GetVideoSurface()` instead of making a new one.
With the 8 bpp surface an exception is raised in `_get_default_masks(..., alpha=True)`.  Fix is to use the surface already created in `setUp()` instead of accessing the screen.