### PR TITLE
Add Python 3.6 to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
 - 3.3
 - 3.4
 - 3.5
+- 3.6
 - nightly
 - pypy
 # Not useable until PyPy 2.6 is available


### PR DESCRIPTION
We should have travis test against 3.6 now