### PR TITLE
Bugs/windows needs explicit binary open

### DIFF
--- a/pygame/font.py
+++ b/pygame/font.py
@@ -151,7 +151,7 @@ class Font(object):
             # Otherwise, if the file handle is closed elsewhere, font
             # rendering will segfault.
             if self._font_file is None:
-                file_obj = open(os.path.abspath(file_obj.name))
+                file_obj = open(os.path.abspath(file_obj.name), 'rb')
                 self._font_file = file_obj
 
             rwops = rwops_from_file(file_obj)

--- a/test/mixer_music_test.py
+++ b/test/mixer_music_test.py
@@ -51,8 +51,8 @@ class MixerMusicModuleTest(unittest.TestCase):
             pygame.mixer.music.load(bmusfn)
 
             # Test loading from filelikes objects
-            pygame.mixer.music.load(open(bmusfn))
-            musf = open(bmusfn)
+            pygame.mixer.music.load(open(bmusfn,"rb"))
+            musf = open(bmusfn, "rb")
             pygame.mixer.music.load(musf)
         pygame.mixer.quit()
 


### PR DESCRIPTION
Windows defaults to using 'cp1252' if the file is opened in text mode, which fails for arbitary binary data. We should be explicit about opening binary objects as binary.