### PR TITLE
Appveyor's Python3.4 64bit setup is buggy, so we drop it.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,10 +26,6 @@ environment:
       PYTHON_ARCH: "64"
       RUN_CONFORMANCE: 0
 
-    - PYTHON: "C:\\Python34-x64"
-      PYTHON_ARCH: "64"
-      RUN_CONFORMANCE: 0
-
     - PYTHON: "C:\\Python35-x64"
       PYTHON_ARCH: "64"
       RUN_CONFORMANCE: 0


### PR DESCRIPTION
See
http://help.appveyor.com/discussions/problems/5415-python-33-x64-and-34-x64-have-improperly-set-up-compilers
for more information.

We can probably work around this by updating setuptools, but
given the age of 3.4 and our other test runs, it seems simplest
to just skip this case.

This has actually been failing for a long time - we just haven't noticed because all the windows builds were failing anyway.