### PR TITLE
Use 16 bit surfaces in conformance tests

### DIFF
--- a/conformance/conf_tests/helpers.py
+++ b/conformance/conf_tests/helpers.py
@@ -73,7 +73,7 @@ def create_surface(depth):
         surf = surface.Surface((800, 600), depth=32, flags=SRCALPHA)
         surf.fill((0, 0, 0, 0xff))
     elif depth in (16, 24):
-        surf = surface.Surface((800, 600), depth=24)
+        surf = surface.Surface((800, 600), depth=depth)
         surf.fill((0, 0, 0, 0xff))
     elif depth == 8:
         surf = surface.Surface((800, 600), depth=8)


### PR DESCRIPTION
I guess we should actually use 16-bit surfaces if we claim to be testing 16 bit surfaces. It's presumably what other people would expect.