### PR TITLE
Force later setuptools version for nightly build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,10 @@ before_install:
          virtualenv -p /usr/bin/pypy $VPATH
          source $VPATH/bin/activate
       fi
+      # This is a workaround until setuptools with the fix is standard
+      if [ "$TRAVIS_PYTHON_VERSION" = "nightly" ]; then
+          pip install setuptools==38.5.1
+      fi
 
 install: pip install -e .
 script:


### PR DESCRIPTION
This works around the current failures we see with Python nightly, by using a version of setuptools that fixes https://github.com/pypa/setuptools/issues/1257

Since the travis-ci people are aware of the problem, though, it might be better drop nightly down to allowed failure until they deploy the fix on their side instead.